### PR TITLE
add reverse

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,13 @@ language: go
 go:
   - "1.x"
   - "1.11.x"
-  - master
+  - "1.12.x"
 
 env:
   - GO111MODULE=on
 
-matrix:
-  allow_failures:
-    - go: master
-
 go_import_path: go.cryptoscope.co/margaret
+
 
 install:
   - go get -t -v go.cryptoscope.co/margaret/...

--- a/mem/log.go
+++ b/mem/log.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 
+	"github.com/pkg/errors"
 	"go.cryptoscope.co/luigi"
 	"go.cryptoscope.co/margaret"
 )
@@ -116,6 +117,10 @@ func (log *memlog) Query(specs ...margaret.QuerySpec) (luigi.Source, error) {
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	if qry.reverse && qry.live {
+		return nil, errors.Errorf("memlog: can't do reverse and live")
 	}
 
 	return qry, nil

--- a/mem/log.go
+++ b/mem/log.go
@@ -131,15 +131,9 @@ func (log *memlog) Append(v interface{}) (margaret.Seq, error) {
 		wait: make(chan struct{}),
 	}
 
-	// scroll to prev
-	var cur = log.head
-	for cur.seq < log.tail.seq && cur.next != nil {
-		cur = cur.next
-	}
-	nxt.prev = cur
-
 	log.tail.next = nxt
 	oldtail := log.tail
+	nxt.prev = oldtail
 	log.tail = log.tail.next
 
 	close(oldtail.wait)

--- a/mem/qry.go
+++ b/mem/qry.go
@@ -121,9 +121,6 @@ func (qry *memlogQuery) Next(ctx context.Context) (interface{}, error) {
 	defer qry.log.l.Unlock()
 
 	if qry.reverse {
-		if qry.live {
-			return nil, errors.Errorf("can't do reverse & live")
-		}
 		if qry.cur == qry.log.head {
 			return qry.cur.v, luigi.EOS{}
 		}

--- a/multilog/sink.go
+++ b/multilog/sink.go
@@ -69,9 +69,9 @@ func (slog *sinkLog) Pour(ctx context.Context, v interface{}) error {
 	return errors.Wrap(err, "multilog/sink: error in processing function")
 }
 
-// Close closes the root-log..? seems wrong
-// rational here beeing having multiple mlogs on one root (?)
-// user needs to know this, then.
+// Close does nothing.
+// TODO: It could close it's backing multilog but that trashes other open sublogs
+// Maybe have something like a "multiple-open tracker" that tracks all the users of the multilog and closes it if all users closed it?
 func (slog *sinkLog) Close() error { return nil } // slog.mlog.Close() }
 
 // QuerySpec returns the query spec that queries the next needed messages from the log

--- a/multilog/sink.go
+++ b/multilog/sink.go
@@ -70,6 +70,8 @@ func (slog *sinkLog) Pour(ctx context.Context, v interface{}) error {
 }
 
 // Close closes the root-log..? seems wrong
+// rational here beeing having multiple mlogs on one root (?)
+// user needs to know this, then.
 func (slog *sinkLog) Close() error { return nil } // slog.mlog.Close() }
 
 // QuerySpec returns the query spec that queries the next needed messages from the log

--- a/multilog/test/all/all.go
+++ b/multilog/test/all/all.go
@@ -3,7 +3,7 @@ package all
 import (
 	// import to register testing helpers
 	_ "go.cryptoscope.co/margaret/mem/test"
-	_ "go.cryptoscope.co/margaret/offset/test"
+	_ "go.cryptoscope.co/margaret/offset2/test"
 
 	_ "go.cryptoscope.co/margaret/multilog/badger/test"
 )

--- a/multilog/test/main.go
+++ b/multilog/test/main.go
@@ -16,7 +16,7 @@ func SinkTest(f NewLogFunc) func(*testing.T) {
 
 func MultiLogTest(f NewLogFunc) func(*testing.T) {
 	return func(t *testing.T) {
-		t.Run("Simple", MultiLogTestSimple(f))
+		t.Run("MultiSimple", MultiLogTestSimple(f))
 	}
 }
 

--- a/multilog/test/multilog.go
+++ b/multilog/test/multilog.go
@@ -2,7 +2,6 @@ package test // import "go.cryptoscope.co/margaret/multilog/test"
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -77,6 +76,7 @@ func MultilogTestAddLogAndListed(f NewLogFunc) func(*testing.T) {
 
 func MultiLogTestSimple(f NewLogFunc) func(*testing.T) {
 	type testcase struct {
+		name    string
 		tipe    interface{}
 		specs   []margaret.QuerySpec
 		values  map[librarian.Addr][]interface{}
@@ -155,7 +155,7 @@ func MultiLogTestSimple(f NewLogFunc) func(*testing.T) {
 				var v_ interface{}
 				err = nil
 
-				for _, v := range results {
+				for i, v := range results {
 					go func() {
 						select {
 						case <-time.After(20 * time.Millisecond):
@@ -172,10 +172,10 @@ func MultiLogTestSimple(f NewLogFunc) func(*testing.T) {
 							sw := v.(margaret.SeqWrapper)
 							sw_ := v_.(margaret.SeqWrapper)
 
-							a.Equal(sw.Seq(), sw_.Seq(), "sequence number doesn't match")
-							a.Equal(sw.Value(), sw_.Value(), "value doesn't match")
+							a.Equal(sw.Seq(), sw_.Seq(), "sequence number doesn't match - result %d", i)
+							a.Equal(sw.Value(), sw_.Value(), "value doesn't match - result %d", i)
 						} else {
-							a.Equal(v, v, "values don't match")
+							a.EqualValues(v, v_, "values don't match - result %d", i)
 						}
 					}
 					if err != nil {
@@ -214,6 +214,8 @@ func MultiLogTestSimple(f NewLogFunc) func(*testing.T) {
 				}
 			}
 
+			r.NoError(mlog.Close(), "failed to close testlog")
+
 			if t.Failed() {
 				t.Log("db location:", dir)
 			} else {
@@ -224,6 +226,7 @@ func MultiLogTestSimple(f NewLogFunc) func(*testing.T) {
 
 	tcs := []testcase{
 		{
+			name:  "simple all",
 			tipe:  margaret.BaseSeq(0),
 			specs: []margaret.QuerySpec{margaret.Live(true)},
 			live:  true,
@@ -272,6 +275,55 @@ func MultiLogTestSimple(f NewLogFunc) func(*testing.T) {
 		},
 
 		{
+			name:  "reverse",
+			tipe:  margaret.BaseSeq(0),
+			specs: []margaret.QuerySpec{margaret.Reverse(true)},
+			values: map[librarian.Addr][]interface{}{
+				librarian.Addr([]byte{0, 0, 0, 2}):  []interface{}{2, 4, 6, 8, 10, 12, 14, 16, 18},
+				librarian.Addr([]byte{0, 0, 0, 3}):  []interface{}{3, 6, 9, 12, 15, 18},
+				librarian.Addr([]byte{0, 0, 0, 4}):  []interface{}{4, 8, 12, 16},
+				librarian.Addr([]byte{0, 0, 0, 5}):  []interface{}{5, 10, 15},
+				librarian.Addr([]byte{0, 0, 0, 6}):  []interface{}{6, 12, 18},
+				librarian.Addr([]byte{0, 0, 0, 7}):  []interface{}{7, 14},
+				librarian.Addr([]byte{0, 0, 0, 8}):  []interface{}{8, 16},
+				librarian.Addr([]byte{0, 0, 0, 9}):  []interface{}{9, 18},
+				librarian.Addr([]byte{0, 0, 0, 10}): []interface{}{10},
+				librarian.Addr([]byte{0, 0, 0, 11}): []interface{}{11},
+				librarian.Addr([]byte{0, 0, 0, 12}): []interface{}{12},
+				librarian.Addr([]byte{0, 0, 0, 12}): []interface{}{12},
+				librarian.Addr([]byte{0, 0, 0, 13}): []interface{}{13},
+				librarian.Addr([]byte{0, 0, 0, 14}): []interface{}{14},
+				librarian.Addr([]byte{0, 0, 0, 15}): []interface{}{15},
+				librarian.Addr([]byte{0, 0, 0, 16}): []interface{}{16},
+				librarian.Addr([]byte{0, 0, 0, 17}): []interface{}{17},
+				librarian.Addr([]byte{0, 0, 0, 18}): []interface{}{18},
+				librarian.Addr([]byte{0, 0, 0, 19}): []interface{}{19},
+			},
+			results: map[librarian.Addr][]interface{}{
+				librarian.Addr([]byte{0, 0, 0, 2}):  []interface{}{18, 16, 14, 12, 10, 8, 6, 4, 2},
+				librarian.Addr([]byte{0, 0, 0, 3}):  []interface{}{18, 15, 12, 9, 6, 3},
+				librarian.Addr([]byte{0, 0, 0, 4}):  []interface{}{16, 12, 8, 4},
+				librarian.Addr([]byte{0, 0, 0, 5}):  []interface{}{15, 10, 5},
+				librarian.Addr([]byte{0, 0, 0, 6}):  []interface{}{18, 12, 6},
+				librarian.Addr([]byte{0, 0, 0, 7}):  []interface{}{14, 7},
+				librarian.Addr([]byte{0, 0, 0, 8}):  []interface{}{16, 8},
+				librarian.Addr([]byte{0, 0, 0, 9}):  []interface{}{18, 9},
+				librarian.Addr([]byte{0, 0, 0, 10}): []interface{}{10},
+				librarian.Addr([]byte{0, 0, 0, 11}): []interface{}{11},
+				librarian.Addr([]byte{0, 0, 0, 12}): []interface{}{12},
+				librarian.Addr([]byte{0, 0, 0, 12}): []interface{}{12},
+				librarian.Addr([]byte{0, 0, 0, 13}): []interface{}{13},
+				librarian.Addr([]byte{0, 0, 0, 14}): []interface{}{14},
+				librarian.Addr([]byte{0, 0, 0, 15}): []interface{}{15},
+				librarian.Addr([]byte{0, 0, 0, 16}): []interface{}{16},
+				librarian.Addr([]byte{0, 0, 0, 17}): []interface{}{17},
+				librarian.Addr([]byte{0, 0, 0, 18}): []interface{}{18},
+				librarian.Addr([]byte{0, 0, 0, 19}): []interface{}{19},
+			},
+		},
+
+		{
+			name:  "limit1",
 			tipe:  margaret.BaseSeq(0),
 			specs: []margaret.QuerySpec{margaret.Limit(1)},
 			values: map[librarian.Addr][]interface{}{
@@ -319,6 +371,7 @@ func MultiLogTestSimple(f NewLogFunc) func(*testing.T) {
 		},
 
 		{
+			name:  "live and gte1",
 			tipe:  margaret.BaseSeq(0),
 			specs: []margaret.QuerySpec{margaret.Live(true), margaret.Gte(margaret.BaseSeq(1))},
 			live:  true,
@@ -367,6 +420,7 @@ func MultiLogTestSimple(f NewLogFunc) func(*testing.T) {
 		},
 
 		{
+			name:  "lte3",
 			tipe:  margaret.BaseSeq(0),
 			specs: []margaret.QuerySpec{margaret.Lte(margaret.BaseSeq(3))},
 			values: map[librarian.Addr][]interface{}{
@@ -414,6 +468,7 @@ func MultiLogTestSimple(f NewLogFunc) func(*testing.T) {
 		},
 
 		{
+			name:  "lt3",
 			tipe:  margaret.BaseSeq(0),
 			specs: []margaret.QuerySpec{margaret.Lt(margaret.BaseSeq(3))},
 			values: map[librarian.Addr][]interface{}{
@@ -462,8 +517,8 @@ func MultiLogTestSimple(f NewLogFunc) func(*testing.T) {
 	}
 
 	return func(t *testing.T) {
-		for i, tc := range tcs {
-			t.Run(fmt.Sprint(i), mkTest(tc))
+		for _, tc := range tcs {
+			t.Run(tc.name, mkTest(tc))
 		}
 	}
 }

--- a/multilog/test/sublog.go
+++ b/multilog/test/sublog.go
@@ -68,7 +68,7 @@ func SubLogTestGet(f NewLogFunc) func(*testing.T) {
 							a.Equal(sw.Seq(), sw_.Seq(), "sequence number doesn't match")
 							a.Equal(sw.Value(), sw_.Value(), "value doesn't match")
 						} else {
-							a.Equal(v, v, "values don't match")
+							a.EqualValues(v, v_, "values don't match")
 						}
 					}
 					if err != nil {
@@ -84,6 +84,8 @@ func SubLogTestGet(f NewLogFunc) func(*testing.T) {
 					t.Errorf("expected error %q but got %q", tc.errStr, err)
 				}
 			}
+
+			r.NoError(mlog.Close(), "failed to close testlog")
 
 			if t.Failed() {
 				t.Log("db location:", dir)

--- a/offset/log.go
+++ b/offset/log.go
@@ -2,6 +2,7 @@ package offset // import "go.cryptoscope.co/margaret/offset"
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"sync"
@@ -28,6 +29,7 @@ type offsetLog struct {
 
 // New returns a new offset log.
 func New(f *os.File, framing margaret.Framing, cdc margaret.Codec) (margaret.Log, error) {
+	fmt.Fprintln(os.Stderr, "margaret/offset v1: deprecation warning. please upgrade to offset2.")
 	log := &offsetLog{
 		f:       f,
 		framing: framing,

--- a/offset/qry.go
+++ b/offset/qry.go
@@ -77,8 +77,7 @@ func (qry *offsetQuery) SeqWrap(wrap bool) error {
 	return nil
 }
 func (qry *offsetQuery) Reverse(yes bool) error {
-	qry.reverse = yes
-	return nil
+	return fmt.Errorf("offset1 query: reverse unsupported")
 }
 
 func (qry *offsetQuery) Next(ctx context.Context) (interface{}, error) {

--- a/offset/qry.go
+++ b/offset/qry.go
@@ -21,6 +21,7 @@ type offsetQuery struct {
 	limit   int
 	live    bool
 	seqWrap bool
+	reverse bool
 	close   chan struct{}
 	err     error
 }
@@ -73,6 +74,10 @@ func (qry *offsetQuery) Live(live bool) error {
 
 func (qry *offsetQuery) SeqWrap(wrap bool) error {
 	qry.seqWrap = wrap
+	return nil
+}
+func (qry *offsetQuery) Reverse(yes bool) error {
+	qry.reverse = yes
 	return nil
 }
 

--- a/offset2/log.go
+++ b/offset2/log.go
@@ -448,6 +448,10 @@ func (log *offsetLog) Query(specs ...margaret.QuerySpec) (luigi.Source, error) {
 		}
 	}
 
+	if qry.reverse && qry.live {
+		return nil, errors.Errorf("offset2: can't do reverse and live")
+	}
+
 	return qry, nil
 }
 

--- a/offset2/test/pump.go
+++ b/offset2/test/pump.go
@@ -79,7 +79,7 @@ func LogTestPump(f mtest.NewLogFunc) func(*testing.T) {
 						a.Equal(sw.Seq(), sw_.Seq(), "sequence number doesn't match")
 						a.Equal(sw.Value(), sw_.Value(), "value doesn't match")
 					} else {
-						a.Equal(v, v_, "values don't match")
+						a.Equal(v, v_, "values don't match: %d", iRes)
 					}
 				}
 
@@ -87,7 +87,6 @@ func LogTestPump(f mtest.NewLogFunc) func(*testing.T) {
 				if tc.live && iRes == len(tc.result) {
 					cancel()
 				}
-
 				return nil
 			})
 
@@ -161,17 +160,13 @@ func LogTestPump(f mtest.NewLogFunc) func(*testing.T) {
 			specs:  []margaret.QuerySpec{margaret.Limit(2)},
 		},
 
-		/* Q: how would one do this without caching the results first?...
-		 => add error that it's unsupported?
 		{
 			name:   "reverse",
 			tipe:   0,
 			values: []interface{}{5, 4, 3, 2, 1},
-			// result: []interface{}{1, 2, 3, 4, 5},
-			errStr: "fail",
+			result: []interface{}{1, 2, 3, 4, 5},
 			specs:  []margaret.QuerySpec{margaret.Reverse(true)},
 		},
-		*/
 
 		{
 			name:   "live",

--- a/offset2/test/pump.go
+++ b/offset2/test/pump.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"testing"
 
@@ -17,6 +16,7 @@ import (
 
 func LogTestPump(f mtest.NewLogFunc) func(*testing.T) {
 	type testcase struct {
+		name    string
 		tipe    interface{}
 		values  []interface{}
 		specs   []margaret.QuerySpec
@@ -95,10 +95,6 @@ func LogTestPump(f mtest.NewLogFunc) func(*testing.T) {
 			r.NoError(err, "error querying log")
 
 			for i, v := range tc.values {
-				// this only happens once!
-				if i == tc.qryTime {
-				}
-
 				seq, err := log.Append(v)
 				r.NoError(err, "error appending to log")
 				r.Equal(margaret.BaseSeq(i), seq, "sequence missmatch")
@@ -119,12 +115,14 @@ func LogTestPump(f mtest.NewLogFunc) func(*testing.T) {
 
 	tcs := []testcase{
 		{
+			name:   "simple",
 			tipe:   0,
 			values: []interface{}{1, 2, 3},
 			result: []interface{}{1, 2, 3},
 		},
 
 		{
+			name:   "gt",
 			tipe:   0,
 			values: []interface{}{1, 2, 3},
 			result: []interface{}{2, 3},
@@ -132,6 +130,7 @@ func LogTestPump(f mtest.NewLogFunc) func(*testing.T) {
 		},
 
 		{
+			name:   "gte1",
 			tipe:   0,
 			values: []interface{}{1, 2, 3},
 			result: []interface{}{2, 3},
@@ -139,6 +138,7 @@ func LogTestPump(f mtest.NewLogFunc) func(*testing.T) {
 		},
 
 		{
+			name:   "lt2",
 			tipe:   0,
 			values: []interface{}{1, 2, 3},
 			result: []interface{}{1, 2},
@@ -146,6 +146,7 @@ func LogTestPump(f mtest.NewLogFunc) func(*testing.T) {
 		},
 
 		{
+			name:   "lte1",
 			tipe:   0,
 			values: []interface{}{1, 2, 3},
 			result: []interface{}{1, 2},
@@ -153,13 +154,27 @@ func LogTestPump(f mtest.NewLogFunc) func(*testing.T) {
 		},
 
 		{
+			name:   "limit2",
 			tipe:   0,
 			values: []interface{}{1, 2, 3},
 			result: []interface{}{1, 2},
 			specs:  []margaret.QuerySpec{margaret.Limit(2)},
 		},
 
+		/* Q: how would one do this without caching the results first?...
+		 => add error that it's unsupported?
 		{
+			name:   "reverse",
+			tipe:   0,
+			values: []interface{}{5, 4, 3, 2, 1},
+			// result: []interface{}{1, 2, 3, 4, 5},
+			errStr: "fail",
+			specs:  []margaret.QuerySpec{margaret.Reverse(true)},
+		},
+		*/
+
+		{
+			name:   "live",
 			tipe:   0,
 			values: []interface{}{1, 2, 3},
 			result: []interface{}{1, 2, 3},
@@ -168,6 +183,7 @@ func LogTestPump(f mtest.NewLogFunc) func(*testing.T) {
 		},
 
 		{
+			name:   "seqWrap",
 			tipe:   0,
 			values: []interface{}{1, 2, 3},
 			result: []interface{}{
@@ -181,8 +197,8 @@ func LogTestPump(f mtest.NewLogFunc) func(*testing.T) {
 	}
 
 	return func(t *testing.T) {
-		for i, tc := range tcs {
-			t.Run(fmt.Sprint(i), mkTest(tc))
+		for _, tc := range tcs {
+			t.Run(tc.name, mkTest(tc))
 		}
 	}
 }

--- a/qry.go
+++ b/qry.go
@@ -13,6 +13,9 @@ type Query interface {
 	// Limit makes the source return only up to n items.
 	Limit(n int) error
 
+	// Reverse makes the source return the lastest values first
+	Reverse(yes bool) error
+
 	// Live makes the source block at the end of the log and wait for new values
 	// that are being appended.
 	Live(bool) error
@@ -94,5 +97,11 @@ func Live(live bool) QuerySpec {
 func SeqWrap(wrap bool) QuerySpec {
 	return func(q Query) error {
 		return q.SeqWrap(wrap)
+	}
+}
+
+func Reverse(yes bool) QuerySpec {
+	return func(q Query) error {
+		return q.Reverse(yes)
 	}
 }

--- a/test/all/all.go
+++ b/test/all/all.go
@@ -3,6 +3,9 @@ package all
 import (
 	// import to register testing helpers
 	_ "go.cryptoscope.co/margaret/mem/test"
+
+	// offset1 tests pass minus the reverse ones. please update to v2
 	// _ "go.cryptoscope.co/margaret/offset/test"
+
 	_ "go.cryptoscope.co/margaret/offset2/test"
 )

--- a/test/all/all.go
+++ b/test/all/all.go
@@ -3,6 +3,6 @@ package all
 import (
 	// import to register testing helpers
 	_ "go.cryptoscope.co/margaret/mem/test"
-	_ "go.cryptoscope.co/margaret/offset/test"
+	// _ "go.cryptoscope.co/margaret/offset/test"
 	_ "go.cryptoscope.co/margaret/offset2/test"
 )

--- a/test/main.go
+++ b/test/main.go
@@ -13,6 +13,5 @@ func LogTest(f NewLogFunc) func(*testing.T) {
 		t.Run("Get", LogTestGet(f))
 		t.Run("Simple", LogTestSimple(f))
 		t.Run("Concurrent", LogTestConcurrent(f))
-		// t.Run("Copy", LogTestCopy(f)) // TODO: what's this supposed to be?
 	}
 }

--- a/test/main.go
+++ b/test/main.go
@@ -13,6 +13,6 @@ func LogTest(f NewLogFunc) func(*testing.T) {
 		t.Run("Get", LogTestGet(f))
 		t.Run("Simple", LogTestSimple(f))
 		t.Run("Concurrent", LogTestConcurrent(f))
-		// t.Run("Copy", LogTestCopy(f))
+		// t.Run("Copy", LogTestCopy(f)) // TODO: what's this supposed to be?
 	}
 }

--- a/test/simple.go
+++ b/test/simple.go
@@ -2,7 +2,6 @@ package test // import "go.cryptoscope.co/margaret/test"
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -17,6 +16,7 @@ import (
 
 func LogTestSimple(f NewLogFunc) func(*testing.T) {
 	type testcase struct {
+		name    string
 		tipe    interface{}
 		values  []interface{}
 		specs   []margaret.QuerySpec
@@ -78,7 +78,7 @@ func LogTestSimple(f NewLogFunc) func(*testing.T) {
 						a.Equal(sw.Seq(), sw_.Seq(), "sequence number doesn't match")
 						a.Equal(sw.Value(), sw_.Value(), "value doesn't match")
 					} else {
-						a.Equal(v, v, "values don't match")
+						a.EqualValues(v, v_, "values don't match")
 					}
 				}
 				if err != nil {
@@ -120,12 +120,30 @@ func LogTestSimple(f NewLogFunc) func(*testing.T) {
 
 	tcs := []testcase{
 		{
+			name:   "simple",
 			tipe:   0,
 			values: []interface{}{1, 2, 3},
 			result: []interface{}{1, 2, 3},
 		},
 
 		{
+			name:   "reverse",
+			tipe:   0,
+			values: []interface{}{1, 2, 3, 4, 5},
+			result: []interface{}{5, 4, 3, 2, 1},
+			specs:  []margaret.QuerySpec{margaret.Reverse(true)},
+		},
+
+		{
+			name:   "reverse-false",
+			tipe:   0,
+			values: []interface{}{1, 2, 3, 4, 5},
+			result: []interface{}{1, 2, 3, 4, 5},
+			specs:  []margaret.QuerySpec{margaret.Reverse(false)},
+		},
+
+		{
+			name:   "gt0",
 			tipe:   0,
 			values: []interface{}{1, 2, 3},
 			result: []interface{}{2, 3},
@@ -133,6 +151,7 @@ func LogTestSimple(f NewLogFunc) func(*testing.T) {
 		},
 
 		{
+			name:   "gte1",
 			tipe:   0,
 			values: []interface{}{1, 2, 3},
 			result: []interface{}{2, 3},
@@ -140,6 +159,7 @@ func LogTestSimple(f NewLogFunc) func(*testing.T) {
 		},
 
 		{
+			name:   "lt2",
 			tipe:   0,
 			values: []interface{}{1, 2, 3},
 			result: []interface{}{1, 2},
@@ -147,6 +167,7 @@ func LogTestSimple(f NewLogFunc) func(*testing.T) {
 		},
 
 		{
+			name:   "lte1",
 			tipe:   0,
 			values: []interface{}{1, 2, 3},
 			result: []interface{}{1, 2},
@@ -154,6 +175,7 @@ func LogTestSimple(f NewLogFunc) func(*testing.T) {
 		},
 
 		{
+			name:   "limit2",
 			tipe:   0,
 			values: []interface{}{1, 2, 3},
 			result: []interface{}{1, 2},
@@ -161,6 +183,7 @@ func LogTestSimple(f NewLogFunc) func(*testing.T) {
 		},
 
 		{
+			name:   "EOS",
 			tipe:   0,
 			values: []interface{}{1, 2},
 			result: []interface{}{1, 2, 3},
@@ -168,6 +191,7 @@ func LogTestSimple(f NewLogFunc) func(*testing.T) {
 		},
 
 		{
+			name:   "live",
 			tipe:   0,
 			values: []interface{}{1, 2, 3},
 			result: []interface{}{1, 2, 3},
@@ -176,6 +200,7 @@ func LogTestSimple(f NewLogFunc) func(*testing.T) {
 		},
 
 		{
+			name:   "seqWrap",
 			tipe:   0,
 			values: []interface{}{1, 2, 3},
 			result: []interface{}{
@@ -189,8 +214,8 @@ func LogTestSimple(f NewLogFunc) func(*testing.T) {
 	}
 
 	return func(t *testing.T) {
-		for i, tc := range tcs {
-			t.Run(fmt.Sprint(i), mkTest(tc))
+		for _, tc := range tcs {
+			t.Run(tc.name, mkTest(tc))
 		}
 	}
 }

--- a/test/simple.go
+++ b/test/simple.go
@@ -192,6 +192,22 @@ func LogTestSimple(f NewLogFunc) func(*testing.T) {
 		},
 
 		{
+			name:   "reverse and gte",
+			tipe:   0,
+			values: []interface{}{1, 2, 3, 4, 5},
+			result: []interface{}{5, 4, 3, 2},
+			specs:  []margaret.QuerySpec{margaret.Reverse(true), margaret.Gte(margaret.BaseSeq(2))},
+		},
+
+		{
+			name:   "reverse and lt",
+			tipe:   0,
+			values: []interface{}{1, 2, 3, 4, 5},
+			result: []interface{}{3, 2, 1},
+			specs:  []margaret.QuerySpec{margaret.Reverse(true), margaret.Lt(margaret.BaseSeq(4))},
+		},
+
+		{
 			name:   "live",
 			tipe:   0,
 			values: []interface{}{1, 2, 3},

--- a/test/simple.go
+++ b/test/simple.go
@@ -3,6 +3,7 @@ package test // import "go.cryptoscope.co/margaret/test"
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -217,5 +218,17 @@ func LogTestSimple(f NewLogFunc) func(*testing.T) {
 		for _, tc := range tcs {
 			t.Run(tc.name, mkTest(tc))
 		}
+
+		t.Run("invalid querys", func(t *testing.T) {
+			r := require.New(t)
+
+			// "live and reverse"
+			log, err := f(t.Name(), 0)
+			r.NoError(err)
+
+			_, err = log.Query(margaret.Live(true), margaret.Reverse(true))
+			r.Error(err)
+			r.True(strings.Contains(err.Error(), ": can't do reverse and live"))
+		})
 	}
 }


### PR DESCRIPTION
this enables getting the last message first and iterating backwards.

I disabled the tests for offset v1 and added a deprecation warning. We only used this format at the beginning of our ssb work. It Still works but I didn't add reverse to it so the tests fail.

cc @keks 