### PR TITLE
Fix live queries

### DIFF
--- a/internal/seqobsv/seqobsv.go
+++ b/internal/seqobsv/seqobsv.go
@@ -1,0 +1,83 @@
+// Package seqobsv wants to supply an observable value sepcialized for sequence numbers in append-only logs.
+// It should be fine for access from multiple goroutines.
+//
+// These values only go up by one. For margaret they start with 0.
+//
+package seqobsv
+
+import (
+	"math"
+	"sync"
+
+	"go.cryptoscope.co/margaret"
+)
+
+type Observable struct {
+	mu  sync.Mutex
+	val uint64
+
+	waiters waitMap
+}
+
+type emptyChan chan struct{}
+type waitMap map[uint64][]emptyChan
+
+// New creates a new Observable
+func New(start uint64) *Observable {
+	return &Observable{
+		val:     start,
+		waiters: make(waitMap),
+	}
+}
+
+// Value returns the current value
+func (seq *Observable) Value() uint64 {
+	seq.mu.Lock()
+	v := seq.val
+	seq.mu.Unlock()
+	return v
+}
+
+func (seq *Observable) Seq() margaret.Seq {
+	seq.mu.Lock()
+	v := seq.val
+	seq.mu.Unlock()
+	if v > math.MaxInt64 {
+		panic("bigger then int64")
+	}
+	return margaret.BaseSeq(v)
+}
+
+func (seq *Observable) Inc() uint64 {
+	seq.mu.Lock()
+	curr := seq.val
+
+	if waiters, has := seq.waiters[curr]; has {
+		for _, ch := range waiters {
+			close(ch)
+		}
+		delete(seq.waiters, curr)
+	}
+	seq.val = seq.val + 1
+	currVal := seq.val
+	seq.mu.Unlock()
+	return currVal
+}
+
+func (seq *Observable) WaitFor(n uint64) <-chan struct{} {
+	seq.mu.Lock()
+	defer seq.mu.Unlock()
+	ch := make(emptyChan)
+	if n < seq.val {
+		go func() { close(ch) }()
+		return ch
+	}
+
+	waitersForN, has := seq.waiters[n]
+	if !has {
+		waitersForN = make([]emptyChan, 0)
+	}
+
+	seq.waiters[n] = append(waitersForN, ch)
+	return ch
+}

--- a/internal/seqobsv/simple_test.go
+++ b/internal/seqobsv/simple_test.go
@@ -1,0 +1,87 @@
+package seqobsv_test
+
+import (
+	"testing"
+
+	"go.cryptoscope.co/margaret/internal/seqobsv"
+)
+
+func TestWaitSimple(t *testing.T) {
+
+	sobs := seqobsv.New()
+
+	if sobs.Value() != 0 {
+		t.Fatal("start should be 0")
+	}
+	ch := sobs.WaitFor(4)
+
+	go func() {
+		for i := 0; i < 5; i++ {
+			sobs.Inc()
+		}
+	}()
+
+	<-ch
+
+	if sobs.Value() < 4 {
+		t.Fatal("should be 5 now")
+	}
+}
+
+func TestWaitMultipleRead(t *testing.T) {
+
+	sobs := seqobsv.New()
+
+	if sobs.Value() != 0 {
+		t.Fatal("start should be 0")
+	}
+
+	ch := sobs.WaitFor(200)
+
+	go func() {
+		for {
+			select {
+			case <-ch:
+				break
+			default:
+			}
+			sobs.Value()
+		}
+	}()
+
+	go func() {
+		for {
+			select {
+			case <-ch:
+				break
+			default:
+			}
+			sobs.Value()
+		}
+	}()
+
+	go func() {
+		for {
+			select {
+			case <-ch:
+				break
+			default:
+			}
+			sobs.Value()
+		}
+	}()
+
+	go func() {
+		for i := 0; i < 201; i++ {
+			sobs.Inc()
+			// time.Sleep(time.Second / 100)
+			// t.Log(i)
+		}
+	}()
+
+	<-ch
+
+	if sobs.Value() < 200 {
+		t.Fatal("should be 200 now")
+	}
+}

--- a/internal/seqobsv/simple_test.go
+++ b/internal/seqobsv/simple_test.go
@@ -1,14 +1,30 @@
 package seqobsv_test
 
 import (
+	"fmt"
 	"testing"
 
 	"go.cryptoscope.co/margaret/internal/seqobsv"
 )
 
+func ExampleInc() {
+	sobs := seqobsv.New(0)
+	fmt.Println(sobs.Value())
+
+	newV := sobs.Inc()
+	fmt.Println(newV)
+
+	fmt.Println(sobs.Inc())
+
+	// Output:
+	// 0
+	// 1
+	// 2
+}
+
 func TestWaitSimple(t *testing.T) {
 
-	sobs := seqobsv.New()
+	sobs := seqobsv.New(0)
 
 	if sobs.Value() != 0 {
 		t.Fatal("start should be 0")
@@ -30,7 +46,7 @@ func TestWaitSimple(t *testing.T) {
 
 func TestWaitMultipleRead(t *testing.T) {
 
-	sobs := seqobsv.New()
+	sobs := seqobsv.New(0)
 
 	if sobs.Value() != 0 {
 		t.Fatal("start should be 0")

--- a/multilog/badger/sublog.go
+++ b/multilog/badger/sublog.go
@@ -99,12 +99,12 @@ func (log *sublog) Append(v interface{}) (margaret.Seq, error) {
 			return errors.Wrap(err, "errors setting value")
 		}
 
-		log.seq.Set(seq)
 		return nil
 	})
 	if err != nil {
 		return margaret.BaseSeq(-2), errors.Wrap(err, "error in write transaction")
 	}
 
+	log.seq.Set(seq)
 	return seq, nil
 }

--- a/multilog/roaringfiles/multilog.go
+++ b/multilog/roaringfiles/multilog.go
@@ -146,7 +146,7 @@ func (log *MultiLog) CompressAll() error {
 
 	// save open ones
 	for addr, sublog := range log.sublogs {
-		err := sublog.update()
+		_, err := sublog.update()
 		if err != nil {
 			return errors.Wrapf(err, "failed to update open sublog %x", addr)
 		}

--- a/multilog/roaringfiles/qry.go
+++ b/multilog/roaringfiles/qry.go
@@ -4,7 +4,6 @@ package roaringfiles
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"sync"
 
@@ -148,7 +147,7 @@ func (qry *query) livequery(ctx context.Context) (interface{}, error) {
 		func(ctx context.Context, v interface{}, err error) error {
 			qry.l.Lock()
 			defer qry.l.Unlock()
-			fmt.Println("live sub query boradcast triggered", v, err)
+			// fmt.Println("live sub query boradcast triggered", v, err)
 			if err != nil {
 				close(closed)
 				return err

--- a/multilog/roaringfiles/qry.go
+++ b/multilog/roaringfiles/qry.go
@@ -4,6 +4,7 @@ package roaringfiles
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 
@@ -147,7 +148,7 @@ func (qry *query) livequery(ctx context.Context) (interface{}, error) {
 		func(ctx context.Context, v interface{}, err error) error {
 			qry.l.Lock()
 			defer qry.l.Unlock()
-			// fmt.Println("live sub query boradcast triggere", v, err)
+			fmt.Println("live sub query boradcast triggered", v, err)
 			if err != nil {
 				close(closed)
 				return err

--- a/multilog/test/main.go
+++ b/multilog/test/main.go
@@ -19,6 +19,7 @@ func SinkTest(f NewLogFunc) func(*testing.T) {
 func MultiLogTest(f NewLogFunc) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Run("MultiSimple", MultiLogTestSimple(f))
+		t.Run("Live", MultilogLiveQueryCheck(f))
 	}
 }
 

--- a/multilog/test/multilog.go
+++ b/multilog/test/multilog.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-package test // import "go.cryptoscope.co/margaret/multilog/test"
+package test
 
 import (
 	"context"

--- a/multilog/test/multilog_live.go
+++ b/multilog/test/multilog_live.go
@@ -1,0 +1,99 @@
+package test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.cryptoscope.co/librarian"
+	"go.cryptoscope.co/luigi"
+	"go.cryptoscope.co/margaret"
+)
+
+func MultilogLiveQueryCheck(f NewLogFunc) func(*testing.T) {
+	return func(t *testing.T) {
+		a := assert.New(t)
+		r := require.New(t)
+		ctx, cancel := context.WithCancel(context.TODO())
+
+		mlog, _, err := f(t.Name(), margaret.BaseSeq(0), "")
+		r.NoError(err)
+
+		// empty yet
+		addrs, err := mlog.List()
+		r.NoError(err, "error listing mlog")
+		r.Len(addrs, 0)
+
+		testLogs := map[librarian.Addr][]margaret.BaseSeq{
+			"fii": []margaret.BaseSeq{1, 2, 3},
+			"faa": []margaret.BaseSeq{100, 200, 300},
+			"foo": []margaret.BaseSeq{4, 5, 6},
+			"fum": []margaret.BaseSeq{7, 8, 9},
+		}
+
+		// fill in some values
+		for name, vals := range testLogs {
+			slog, err := mlog.Get(name)
+			r.NoError(err)
+
+			for i, v := range vals {
+				_, err := slog.Append(v)
+				r.NoError(err, "valied to append %s:%d", name, i)
+			}
+
+			v, err := slog.Seq().Value()
+			r.NoError(err)
+			r.EqualValues(v, len(vals)-1)
+		}
+
+		logOfFaa, err := mlog.Get(librarian.Addr("faa"))
+		r.NoError(err)
+
+		seqSrc, err := logOfFaa.Query(
+			margaret.Gt(margaret.BaseSeq(2)),
+			margaret.Live(true),
+		)
+		r.NoError(err)
+
+		// produce new values in the background
+		go func() {
+			time.Sleep(1 * time.Second)
+			slog, err := mlog.Get(librarian.Addr("faa"))
+			if err != nil {
+				panic(err)
+			}
+			for tv := 400; tv < 1000; tv += 100 {
+				seq, err := slog.Append(tv)
+				if err != nil {
+					panic(err)
+				}
+				t.Log(tv, " inserted as:", seq)
+				// !!!!!
+				time.Sleep(time.Second / 10)
+				// !!!!!
+			}
+			time.Sleep(1 * time.Second)
+			cancel()
+		}()
+
+		var expSeq = 3
+		for {
+			seqV, err := seqSrc.Next(ctx)
+			if err != nil {
+				if luigi.IsEOS(err) || errors.Cause(err) == context.Canceled {
+					t.Log("canceled")
+					a.Equal(expSeq, 9)
+					break
+				}
+				r.NoError(err)
+			}
+			seq := seqV.(margaret.Seq)
+			a.EqualValues(expSeq, seq.Seq(), "wrong seq value from query")
+			expSeq++
+		}
+	}
+}

--- a/multilog/test/multilog_live.go
+++ b/multilog/test/multilog_live.go
@@ -66,8 +66,11 @@ func MultilogLiveQueryCheck(f NewLogFunc) func(*testing.T) {
 					panic(err)
 				}
 				t.Log(tv, " inserted as:", appendedSeq)
+				// !!!! handbrake to reduce chan send shedule madness
+				time.Sleep(time.Second / 10)
+				// !!!!!
 			}
-			time.Sleep(time.Second / 3)
+			time.Sleep(time.Second / 2)
 			cancel()
 		}()
 


### PR DESCRIPTION
I added `multilog/test/multilog_live.go` and it showed some problems in both the badger and roaring bitmap multilog implementations.

This PR
* [x] fixes values returned by livequeries
* [x] correctly waits for values to be added
* [x] adds a simplified _sequence observable_ that is easier to use then luigis abstract one