### PR TITLE
Local fork fix investigation

### DIFF
--- a/multilog/roaring/multilog.go
+++ b/multilog/roaring/multilog.go
@@ -119,7 +119,7 @@ func (log *MultiLog) openSublog(addr indexes.Addr) (*sublog, error) {
 	} else if err != nil {
 		return nil, err
 	} else {
-		seq = int64(r.GetCardinality() - 1)
+		seq = int64(r.GetCardinality())
 	}
 
 	var obsV uint64

--- a/multilog/test/main.go
+++ b/multilog/test/main.go
@@ -20,6 +20,8 @@ func SinkTest(f NewLogFunc) func(*testing.T) {
 
 func MultiLogTest(f NewLogFunc) func(*testing.T) {
 	return func(t *testing.T) {
+		// makes sure local fork reproduction doesn't make a reappearance
+		t.Run("GetFreshThenReopenAndLogSomeMore",  MultilogTestGetFreshLogCloseThenOpenAgain(f))
 		t.Run("MultiSimple", MultiLogTestSimple(f))
 		t.Run("Live", MultilogLiveQueryCheck(f))
 	}


### PR DESCRIPTION
Hallo hallo!

Investigating an issue I found together with glyph when working on [Peachcloud](https://opencollective.com/peachcloud)'s new Peachpub utility.

The situation:
* Start a fresh go-sbot
* Post some messages
* Stop it
* Some time later: start it again
* Post more messages
* Uh-oh the first new message seems to fork, using the previous-to-last message (instead of the last message) as it's `previous` reference, and with a seqno that is one less than it should be

To test this more thoroughly, I created a reproduction test case in go-ssb proper (PR forthcoming), which has the following failure output for the above scenario:

```
    local_fork_test.go:58: 
                Error Trace:    local_fork_test.go:58
                Error:          Not equal: 
                                expected: int(1)
                                actual  : int64(0)
                Test:           TestStartup
                Messages:       maggie seqno of log with 2 messages should be 1
    local_fork_test.go:64: 
                Error Trace:    local_fork_test.go:64
                Error:          Not equal: 
                                expected: int(2)
                                actual  : int64(1)
                Test:           TestStartup
                Messages:       maggie seqno of log with 3 messages should be 2
    local_fork_test.go:71: 
                Error Trace:    local_fork_test.go:71
                Error:          Not equal: 
                                expected: int(3)
                                actual  : int64(2)
                Test:           TestStartup
                Messages:       maggie seqno of log with 4 messages should be 3
```

The culprit driving this behaviour was ostensibly narrowed down to `margaret@v0.4.0`, as the reproduction test case passes when go-sbot is running with `margaret@v0.3.0`. This matches up exactly with a large (and otherwise much appreciated wrt the vastly improved UX it resulted in!) refactor of `margaret` that took place.

I'm opening this PR as part of looking into a solution to this problem. The current state of this PR is being opened with a commit that (apparently?!) fixes the reproduction, and as far as ~~I can see while writing this comment, the `margaret` tests also pass~~ edit2: ~~ahah okay no the test suite apparently fails. The search continues!~~ wait no the latest commit fixes it!!?? repo tests pass and my reproduction is all green, too!! 🎢 

🔍 

2022-02-16: this has now been tested with the wip version of [Peachcloud](https://opencollective.com/peachcloud) and we can confirm that the local fork is gone and no other strange behaviour made an appearance :^)